### PR TITLE
Replace the badge with the one generated by Github

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # learn-cicd-starter (Notely)
 
-![Git workflow status badge]("https://github.com/katsuikeda/learn-cicd-starter/actions/workflows/ci.yml/badge.svg")
+[![CI](https://github.com/katsuikeda/learn-cicd-starter/actions/workflows/ci.yml/badge.svg)](https://github.com/katsuikeda/learn-cicd-starter/actions/workflows/ci.yml)
 
 This repo contains the starter code for the "Notely" application for the "Learn CICD" course on [Boot.dev](https://boot.dev).
 


### PR DESCRIPTION
The format that the lesson instructuon in Boot.dev and [Github's instruction about dynamic badges] does't work somehow. Instead of the given format, using badges you can generate from Actions tab work.