### PR TITLE
Add formatting check to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,5 +21,10 @@ jobs:
       - name: Run unit tests
         run: go test -cover ./...
 
-      - name: Check code style
-        run: go fmt ./...
+  style:
+    name: Style
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Formatting check
+        run: test -z $(go fmt ./...)


### PR DESCRIPTION
`go fmt ./...` always exits with 0, so fixed the command to `test -z $(go fmt ./...)` to check the stdout result of `go fmt ./...`.
Also, made an independent CI check for code style.