### PR TITLE
Add Google Cloud authentication and build steps to CD

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -20,3 +20,17 @@ jobs:
 
       - name: Build app
         run: ./scripts/buildprod.sh
+
+      - name: "Google Auth"
+        uses: "google-github-actions/auth@v2"
+        with:
+          credentials_json: "${{ secrets.GCP_CREDENTIALS }}"
+
+      - name: "Set up Cloud SDK"
+        uses: "google-github-actions/setup-gcloud@v2"
+
+      - name: "Use gcloud CLI"
+        run: 'gcloud auth list --filter=status:ACTIVE --format="value(account)"'
+
+      - name: "Build, tag, and push image to Google Container Registry"
+        run: gcloud builds submit --tag us-central1-docker.pkg.dev/notely-445316/notely-ar-repo/notely .


### PR DESCRIPTION
- Add Google Cloud authentication using service account
- Configure gcloud CLI setup
- Add step to build and push Docker image to Artifact Registry